### PR TITLE
ACF output + custom post team

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -134,6 +134,49 @@ function funfun_widgets_init() {
 }
 add_action( 'widgets_init', 'funfun_widgets_init' );
 
+
+// Add custom post type for teams
+function create_team_post_type() {
+    $labels = array(
+        'name'               => 'Teams',
+        'singular_name'      => 'Team',
+        'menu_name'          => 'Teams',
+        'name_admin_bar'     => 'Team',
+        'add_new'            => 'Add New',
+        'add_new_item'       => 'Add New Team',
+        'new_item'           => 'New Team',
+        'edit_item'          => 'Edit Team',
+        'view_item'          => 'View Team',
+        'all_items'          => 'All Teams',
+        'search_items'       => 'Search Teams',
+        'parent_item_colon'  => 'Parent Teams:',
+        'not_found'          => 'No teams found.',
+        'not_found_in_trash' => 'No teams found in Trash.'
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'publicly_queryable' => true,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'query_var'          => true,
+        'rewrite'            => array( 'slug' => 'team' ),
+        'capability_type'    => 'page',
+        'has_archive'        => true,
+        'hierarchical'       => false,
+        'menu_position'      => null,
+        'menu_icon'          => 'dashicons-groups', // Add menu icon
+        'show_in_rest'		 => true,
+        'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' )
+    );
+
+    register_post_type( 'team', $args );
+}
+add_action( 'init', 'create_team_post_type' );
+
+
+
 /**
  * Enqueue scripts and styles.
  */

--- a/header.php
+++ b/header.php
@@ -37,7 +37,9 @@
 			<div class="site-header">
 				<div class="content-width header-container">
 					<div class="site-branding donk-site-branding">
-						<img src="<?php echo get_template_directory_uri() ?>/assets/images/logo.png" alt="donk logo" class="logo" />
+						<a href="<?php echo esc_url( home_url( '/' ) ); ?>">
+							<img src="<?php echo get_template_directory_uri() ?>/assets/images/logo.png" alt="donk logo" class="logo" />
+						</a>
 
 						<!-- Comment OUT -->
 						<!-- <?php
@@ -76,7 +78,21 @@
 						);
 
 						?>
-						<!-- <button>Lid worden</button> -->
+
+						<!-- Output ClientID uit ACF plugin & cms-bare knop in nav -->
+						<?php 
+						$clientid = get_field('clientid', 'option');
+						$button_nav_text =  get_field('button_nav_text', 'option');
+						$button_nav_link =  get_field('button_nav_link', 'option');
+
+							echo 'Output ClientID: '.$clientid;
+
+							if (isset($button_nav_link)) {
+								echo '<a href="' . $button_nav_link . '">' . $button_nav_text . '</a>';
+							}
+						?>
+
+
 					</nav><!-- #site-navigation -->
 				</div>
 			</div>

--- a/single-team.php
+++ b/single-team.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * The template for displaying all single posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package DonkTest
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+
+		<?php
+		while ( have_posts() ) :
+			the_post();
+
+			get_template_part( 'template-parts/content', 'team' );
+
+			the_post_navigation(
+				array(
+					'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous:', 'funfun' ) . '</span> <span class="nav-title">%title</span>',
+					'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next:', 'funfun' ) . '</span> <span class="nav-title">%title</span>',
+				)
+			);
+
+			// If comments are open or we have at least one comment, load up the comment template.
+			if ( comments_open() || get_comments_number() ) :
+				comments_template();
+			endif;
+
+		endwhile; // End of the loop.
+		?>
+
+	</main><!-- #main -->
+
+<?php
+get_sidebar();
+get_footer();

--- a/template-parts/content-team.php
+++ b/template-parts/content-team.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Template part for displaying page content in page.php
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package DonkTest
+ */
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<header class="entry-header">
+		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+	</header><!-- .entry-header -->
+
+	<?php funfun_post_thumbnail(); ?>
+
+	<div class="entry-content">
+		<?php
+		the_content();
+
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'funfun' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+	</div><!-- .entry-content -->
+
+	<!-- TEAM OUTPUT -->
+	<?php 
+		$teamcode =  get_field('teamcode');
+		echo 'teamcode: '.$teamcode;
+	?>
+
+	<?php if ( get_edit_post_link() ) : ?>
+		<footer class="entry-footer">
+			<?php
+			edit_post_link(
+				sprintf(
+					wp_kses(
+						/* translators: %s: Name of current post. Only visible to screen readers */
+						__( 'Edit <span class="screen-reader-text">%s</span>', 'funfun' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					),
+					wp_kses_post( get_the_title() )
+				),
+				'<span class="edit-link">',
+				'</span>'
+			);
+			?>
+		</footer><!-- .entry-footer -->
+	<?php endif; ?>
+</article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
- Client ID in nav, mag verplaatst worden buiten nav
- Instelbare button via ACF (link en tekst)
- Nieuwe custom post 'team'
- Eigen single (single-team) en content-team
- Per team kan er een teamcode worden ingevuld. Je kan $teamcode gebruiken voor programma, uitslagen en stand